### PR TITLE
Added the ability to dump the mock configuration from memory to disk:

### DIFF
--- a/src/controllers/api/post_create_mock.rs
+++ b/src/controllers/api/post_create_mock.rs
@@ -19,6 +19,7 @@ struct CreateMockParams {
     path: String,
     method: String,
     status_code: u16,
+    delay_ms: Option<u64>,
     headers: HashMap<String, String>,
     body: String,
 }
@@ -32,7 +33,13 @@ pub async fn post_create_mock(
 
     match response_cache {
         Some(cache) => {
-            let body_bytes = req.body().clone().collect().await.unwrap_or_default().to_bytes();
+            let body_bytes = req
+                .body()
+                .clone()
+                .collect()
+                .await
+                .unwrap_or_default()
+                .to_bytes();
             let body_str = String::from_utf8(body_bytes.to_vec()).unwrap_or(String::new());
             let create_mock_params = serde_json::from_str::<CreateMockParams>(&body_str);
 
@@ -44,6 +51,7 @@ pub async fn post_create_mock(
                     tokio::spawn(async move {
                         let response = &CachedResponse::new(
                             mock_params.status_code,
+                            mock_params.delay_ms.unwrap_or(0),
                             mock_params.headers,
                             mock_params.body,
                         );

--- a/src/controllers/api/post_dump_mock.rs
+++ b/src/controllers/api/post_dump_mock.rs
@@ -1,7 +1,9 @@
+use crate::libs::mock_config::MockConfig;
 use crate::libs::mockers_errors::MockersErrors;
 use crate::libs::protocol_result::ProtocolResultConverter;
 use crate::libs::response_cache::{MethodNormalizer, PathDecoder, PathNormalizer};
 use crate::server::mockers_context::MockersContext;
+use crate::server::params::CONFIG_FILE_NAME;
 use http_body_util::Full;
 use hyper::body::Bytes;
 use hyper::header::CONTENT_TYPE;
@@ -9,10 +11,11 @@ use hyper::{Request, Response, StatusCode};
 use mimetype_detector::APPLICATION_JSON;
 use path_absolutize::Absolutize;
 use routerify_ng::ext::RequestExt;
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::fs::{create_dir_all, metadata, write};
+use tokio::fs::{self, create_dir_all, metadata, write};
 
 pub async fn post_dump_mock(
     req: Request<Full<Bytes>>,
@@ -99,16 +102,47 @@ pub async fn post_dump_mock(
             .unwrap_or_default());
     };
 
-    let (absolute_target_file_name, absolute_target_directory) =
-        (absolute_target_file_name.to_path_buf().clone(), {
+    let (
+        absolute_target_file_name,
+        absolute_target_directory,
+        absolute_target_config_file_name,
+        config_entry_name,
+    ) = (
+        absolute_target_file_name.to_path_buf().clone(),
+        {
             let mut result = absolute_target_file_name.to_path_buf().clone();
             result.pop();
             result
-        });
+        },
+        {
+            let mut result = absolute_target_file_name.to_path_buf().clone();
+            result.pop();
+            result.join(CONFIG_FILE_NAME)
+        },
+        {
+            absolute_target_file_name
+                .to_path_buf()
+                .clone()
+                .iter()
+                .last()
+                .map(|s| s.to_string_lossy().to_string())
+        },
+    );
 
     if let Ok(md) = metadata(&absolute_target_directory).await
         && md.is_dir()
     {
+        if let Some(config_entry_name) = config_entry_name {
+            // TODO: add logging here
+            let _result = write_mock_config(
+                absolute_target_config_file_name,
+                config_entry_name,
+                cached.delay_ms,
+                cached.status_code,
+                &cached.headers,
+            )
+            .await;
+        }
         return write_file_contents_and_get_response(&absolute_target_file_name, &cached.body)
             .await;
     }
@@ -125,7 +159,56 @@ pub async fn post_dump_mock(
             .unwrap_or_default());
     }
 
+    if let Some(config_entry_name) = config_entry_name {
+        // TODO: add logging here
+        let _result = write_mock_config(
+            absolute_target_config_file_name,
+            config_entry_name,
+            cached.delay_ms,
+            cached.status_code,
+            &cached.headers,
+        )
+        .await;
+    }
+
     write_file_contents_and_get_response(&absolute_target_file_name, &cached.body).await
+}
+
+async fn write_mock_config(
+    to: impl AsRef<Path>,
+    entry_name: impl Into<String>,
+    delay_ms: u64,
+    status_code: u16,
+    headers: &HashMap<String, String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mock_config = MockConfig {
+        headers: match headers.is_empty() {
+            true => None,
+            false => Some(headers.clone()),
+        },
+        status_code: Some(status_code),
+        delay_ms: match delay_ms {
+            0 => None,
+            _ => Some(delay_ms),
+        },
+        cache_mode: None,
+    };
+    let existing_config = fs::read(&to).await.ok().and_then(|contents| {
+        serde_json::from_slice::<HashMap<String, MockConfig>>(&contents.as_ref()).ok()
+    });
+
+    if let Some(mut existing_config) = existing_config {
+        existing_config.insert(entry_name.into(), mock_config);
+        let updated = serde_json::to_string(&existing_config)?;
+        fs::write(to, updated).await?;
+    } else {
+        let mut new_map = HashMap::with_capacity(1);
+        new_map.insert(entry_name.into(), mock_config);
+        let json = serde_json::to_string(&new_map)?;
+        fs::write(to, json).await?;
+    }
+
+    Ok(())
 }
 
 async fn write_file_contents_and_get_response(

--- a/src/controllers/mock_handler.rs
+++ b/src/controllers/mock_handler.rs
@@ -8,7 +8,7 @@ use crate::libs::response_cache::{MethodNormalizer, PathNormalizer};
 use crate::libs::{cache_mode::CacheMode, get_mime::get_mime, mock_config::read_config};
 use crate::server::mockers_context::MockersContext;
 use crate::server::params::{
-    DEFAULT_CORS_ENABLED, DEFAULT_MOCKS_RESPONSE_DELAY, DEFAULT_VERBOSE_ENABLED,
+    CONFIG_FILE_NAME, DEFAULT_CORS_ENABLED, DEFAULT_MOCKS_RESPONSE_DELAY, DEFAULT_VERBOSE_ENABLED,
 };
 use http_body_util::{BodyExt, Full};
 use hyper::{body::Bytes, Request, Response, StatusCode};
@@ -81,7 +81,7 @@ pub async fn mock_handler(req: Request<Full<Bytes>>) -> Result<Response<Full<Byt
      */
     let config_file_path = absolute_mocks_dir
         .join(relative_current_mock_config_dir)
-        .join("config.json");
+        .join(CONFIG_FILE_NAME);
     let config = read_config(&config_file_path).await;
 
     let delay = config
@@ -123,7 +123,8 @@ pub async fn mock_handler(req: Request<Full<Bytes>>) -> Result<Response<Full<Byt
     )
     .await;
 
-    if let Some(response) = cached_data {
+    if let Some((response, delay_ms)) = cached_data {
+        sleep(Duration::from_millis(delay_ms)).await;
         return Ok(response);
     }
 

--- a/src/controllers/swagger/swagger.yaml
+++ b/src/controllers/swagger/swagger.yaml
@@ -307,12 +307,16 @@ components:
     CachedResponse:
       type: object
       description: "Cached response"
-      required: [statusCode, headers, body]
+      required: [statusCode, delayMs, headers, body]
       properties:
         statusCode:
           type: integer
           description: "HTTP response status code"
           example: 201
+        delayMs:
+          type: integer
+          description: "Time to wait before respond in milliseconds"
+          example: 1000
         headers:
           $ref: "#/components/schemas/HeadersMap"
         body:
@@ -328,6 +332,7 @@ components:
         "X-Server": "Mockers"
     CreateMockParams:
       type: object
+      required: [path, method, statusCode, headers, body]
       properties:
         path:
           type: string
@@ -337,6 +342,10 @@ components:
         statusCode:
           type: integer
           description: "HTTP status code to be sent"
+        delayMs:
+          type: integer
+          description: "Time in milliseconds before respond"
+          nullable: true
         headers:
           $ref: "#/components/schemas/HeadersMap"
         body:

--- a/src/controllers/utils.rs
+++ b/src/controllers/utils.rs
@@ -81,7 +81,7 @@ pub async fn get_response_from_cache<P, M>(
     pathname: P,
     method: M,
     cors: bool,
-) -> Option<Response<Full<Bytes>>>
+) -> Option<(Response<Full<Bytes>>, u64)>
 where
     P: Into<String>,
     M: Into<String>,
@@ -112,7 +112,7 @@ where
         );
         builder = add_headers(builder, cors, &headers);
 
-        return Some(builder.body(c.body.into()).unwrap_or(Response::default()));
+        return Some((builder.body(c.body.into()).unwrap_or(Response::default()), c.delay_ms));
     }
 
     None

--- a/src/libs/mock_config.rs
+++ b/src/libs/mock_config.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, path::Path};
 use tokio::fs::read_to_string;
 
 use crate::libs::cache_mode::CacheMode;
@@ -13,7 +13,7 @@ pub struct MockConfig {
     pub cache_mode: Option<CacheMode>,
 }
 
-pub async fn read_config(path: &PathBuf) -> Option<HashMap<String, MockConfig>> {
+pub async fn read_config(path: impl AsRef<Path>) -> Option<HashMap<String, MockConfig>> {
     read_to_string(path)
         .await
         .ok()

--- a/src/libs/response_cache.rs
+++ b/src/libs/response_cache.rs
@@ -9,6 +9,7 @@ use tokio::sync::RwLock;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CachedResponse {
     pub status_code: u16,
+    pub delay_ms: u64,
     pub headers: HashMap<String, String>,
     pub body: String,
     #[serde(skip)]
@@ -16,9 +17,10 @@ pub struct CachedResponse {
 }
 
 impl CachedResponse {
-    pub fn new(status_code: u16, headers: HashMap<String, String>, body: String) -> CachedResponse {
+    pub fn new(status_code: u16, delay_ms: u64, headers: HashMap<String, String>, body: String) -> CachedResponse {
         CachedResponse {
             status_code,
+            delay_ms,
             headers,
             body,
             mime: Arc::new(RwLock::new(None)),

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -10,6 +10,7 @@ pub const DEFAULT_MOCKS_DIR: &'static str = "mocks";
 pub const DEFAULT_MOCKS_RESPONSE_DELAY: u64 = 0;
 pub const DEFAULT_CORS_ENABLED: bool = false;
 pub const DEFAULT_VERBOSE_ENABLED: bool = false;
+pub const CONFIG_FILE_NAME: &'static str = "config.json";
 
 #[derive(Args, Debug, Clone)]
 pub struct ServerParams {


### PR DESCRIPTION
headers, delay time before response, and response code