### PR TITLE
Add interactive mode to mock creation wizard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,6 +433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
  "console",
+ "fuzzy-matcher",
  "shell-words",
  "tempfile",
  "zeroize",
@@ -592,6 +593,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -1922,6 +1932,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path-absolutize = "3.1.1"
 raffia = "0.12.2"
 lru = "0.16.3"
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
-dialoguer = "0.12.0"
+dialoguer = { version = "0.12.0", features = ["fuzzy-select"] }
 anyhow = "1.0.102"
 log = "0.4.29"
 simplelog = "0.12.2"

--- a/src/libs/cache_mode.rs
+++ b/src/libs/cache_mode.rs
@@ -3,12 +3,18 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
-#[derive(ValueEnum, Clone, Debug, Serialize, PartialEq, PartialOrd)]
+#[derive(ValueEnum, Clone, Copy, Debug, Serialize, PartialEq, PartialOrd)]
 #[clap(rename_all = "lowercase")]
 #[serde(rename_all = "lowercase")]
 pub enum CacheMode {
     Overwrite,
     NoCache,
+}
+
+impl CacheMode {
+    pub fn all_values() -> Vec<CacheMode> {
+        return vec![CacheMode::NoCache, CacheMode::Overwrite];
+    }
 }
 
 impl Display for CacheMode {

--- a/src/libs/create_params.rs
+++ b/src/libs/create_params.rs
@@ -7,9 +7,12 @@ use std::path::Path;
 use crate::libs::absolute_mocks_path::{AbsoluteMocksPath, WithMocks};
 use crate::libs::cache_mode::CacheMode;
 use crate::libs::global_config::{GlobalConfigAPI, WithGlobalConfigAPI};
+use crate::libs::http_method::HyperHTTPMethodExt;
 use crate::libs::mock_config::MockConfig;
 use crate::libs::path_buf_ext::PathBufExt;
+use crate::libs::status_code_ext::StatusCode;
 use crate::server::params::CONFIG_FILE_NAME;
+use crate::server::params::DEFAULT_PORT;
 use clap::Args;
 use serde_json::json;
 use tokio::sync::OnceCell;
@@ -45,47 +48,180 @@ pub struct CreateParams {
     #[arg(long, default_value_t = false, help = "Should mock be disabled or not")]
     disabled: bool,
 
+    #[arg(long, short, default_value_t = false, help = "Run in interactive mode")]
+    interactive: bool,
+
     /// Pathname to create mock for
-    route: String,
+    route: Option<String>,
 
     #[clap(skip)]
     global_config: OnceCell<GlobalConfigAPI>,
 }
 
 impl CreateParams {
-    fn method(&self) -> &str {
-        &self.method
+    fn method(&self) -> String {
+        let all_http_methods = hyper::Method::get_all_methods()
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<String>>();
+        let method = self.method.to_owned();
+        match self.interactive {
+            true => dialoguer::FuzzySelect::new()
+                .with_prompt("Select HTTP method")
+                .items(&all_http_methods)
+                .default(0)
+                .interact()
+                .ok()
+                .and_then(|idx| all_http_methods.get(idx))
+                .cloned()
+                .unwrap_or(DEFAULT_METHOD.to_string()),
+            false => method,
+        }
     }
 
-    fn route(&self) -> &str {
-        &self.route
+    fn route(&self) -> String {
+        let dialog = dialoguer::Input::new().with_prompt("Specify URL path");
+        match (self.interactive, &self.route) {
+            (true, Some(route)) => dialog
+                .with_initial_text(route)
+                .interact()
+                .unwrap_or_default(),
+            (false, Some(route)) => route.clone(),
+            (true, None) | (false, None) => dialog.interact().unwrap_or_default(),
+        }
     }
 
     fn status_code(&self) -> u16 {
-        self.status_code
+        let all_codes = u16::get_all_status_codes();
+        let codes: Vec<String> = all_codes.iter().map(StatusCode::pretty_print).collect();
+        match &self.interactive {
+            true => dialoguer::FuzzySelect::new()
+                .with_prompt("Specify http Response code")
+                .items(&codes)
+                .default(0)
+                .interact()
+                .ok()
+                .and_then(|idx| all_codes.get(idx).cloned())
+                .unwrap_or(DEFAULT_PORT),
+            false => self.status_code,
+        }
+    }
+
+    fn delay_ms(&self) -> Option<u64> {
+        match &self.interactive {
+            false => self.delay_ms,
+            true => {
+                let res = dialoguer::Input::new()
+                    .with_prompt("Specify delay in milliseconds before response")
+                    .validate_with(|v: &String| {
+                        v.parse::<u64>()
+                            .map(|_| ())
+                            .map_err(|_| "Invalid delay time")
+                    })
+                    .interact()
+                    .ok()
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .unwrap_or(DEFAULT_DELAY_MS);
+                Some(res)
+            }
+        }
     }
 
     fn cache_mode(&self) -> Option<CacheMode> {
-        self.cache_mode.clone()
+        let all_cache_modes = CacheMode::all_values();
+        let prompt = format!(
+            "Select cache mode. Prefer \"{}\" to cache non-existing responses and \"{}\" not to cache them at all.",
+            CacheMode::Overwrite,
+            CacheMode::NoCache
+        );
+        match &self.interactive {
+            true => {
+                let res = dialoguer::Select::new()
+                    .with_prompt(prompt)
+                    .items(&all_cache_modes)
+                    .default(0)
+                    .interact()
+                    .ok()
+                    .and_then(|idx| all_cache_modes.get(idx))
+                    .cloned()
+                    .unwrap_or(CacheMode::NoCache);
+                return Some(res);
+            }
+            false => self.cache_mode().clone(),
+        }
     }
 
-    fn headers(&self) -> impl Iterator<Item = (&str, &str)> {
-        self.headers.iter().filter_map(|v| {
-            v.split_once(':')
-                .map(|(k, v)| (k.trim(), v.trim()))
-                .filter(|(k, v)| !k.is_empty() && !v.is_empty())
-        })
+    fn headers(&self) -> Vec<(String, String)> {
+        if !&self.interactive {
+            return self
+                .headers
+                .iter()
+                .filter_map(|v| {
+                    v.split_once(':')
+                        .map(|(k, v)| (k.trim(), v.trim()))
+                        .filter(|(k, v)| !k.is_empty() && !v.is_empty())
+                        .map(|(k, v)| (k.to_string(), v.to_string()))
+                })
+                .collect();
+        }
+
+        let mut acc = Vec::new();
+
+        while dialoguer::Confirm::new()
+            .with_prompt(match acc.is_empty() {
+                true => "Add headers?",
+                false => "Add more headers?",
+            })
+            .interact()
+            .unwrap_or(false)
+        {
+            let header_key = dialoguer::Input::new()
+                .with_prompt("Specify header key")
+                .interact()
+                .ok()
+                .unwrap_or("".to_string())
+                .trim()
+                .to_string();
+            let header_value = dialoguer::Input::new()
+                .with_prompt("Specify header value")
+                .interact()
+                .ok()
+                .unwrap_or("".to_string())
+                .trim()
+                .to_string();
+            acc.push((header_key, header_value));
+        }
+
+        return acc;
     }
 
     fn is_disabled(&self) -> bool {
-        self.disabled
+        match self.interactive {
+            true => dialoguer::Confirm::new()
+                .with_prompt("Create this mock disabled?")
+                .default(false)
+                .show_default(true)
+                .interact()
+                .unwrap_or(false),
+            false => self.disabled,
+        }
     }
 
-    fn contents(&self) -> Option<&str> {
-        if let Some(ref c) = self.contents {
-            return Some(c);
+    fn contents(&self) -> Option<String> {
+        let initial_text = self.contents.as_ref().cloned().unwrap_or_default();
+        match &self.interactive {
+            false => self.contents.to_owned(),
+            true => {
+                let res = dialoguer::Input::new()
+                    .with_prompt("Write mock contents")
+                    .allow_empty(false)
+                    .with_initial_text(initial_text)
+                    .interact()
+                    .ok()
+                    .unwrap_or_default();
+                return Some(res);
+            }
         }
-        None
     }
 
     pub async fn test(&self) -> Result<(), Box<dyn StdError + Sync + Send>> {
@@ -142,13 +278,17 @@ impl CreateParams {
 
 impl From<&CreateParams> for MockConfig {
     fn from(value: &CreateParams) -> Self {
-        let owned_headers = value.headers().fold(HashMap::new(), |mut map, (key, val)| {
-            map.insert(key.to_string(), val.to_string());
-            map
-        });
+        let owned_headers =
+            value
+                .headers()
+                .into_iter()
+                .fold(HashMap::new(), |mut map, (key, val)| {
+                    map.insert(key, val);
+                    map
+                });
         MockConfig::new()
             .with_headers(owned_headers)
-            .with_delay_ms(value.delay_ms.unwrap_or(DEFAULT_DELAY_MS))
+            .with_delay_ms(value.delay_ms().unwrap_or(DEFAULT_DELAY_MS))
             .with_status_code(value.status_code())
             .with_cache_mode(value.cache_mode().unwrap_or(CacheMode::NoCache))
             .with_disabled_status(value.is_disabled())

--- a/src/libs/get_mime.rs
+++ b/src/libs/get_mime.rs
@@ -1,10 +1,10 @@
-use mimetype_detector::detect;
 use mimetype_detector::APPLICATION_JSON;
 use mimetype_detector::APPLICATION_OCTET_STREAM;
 use mimetype_detector::TEXT_PLAIN;
+use mimetype_detector::TEXT_UTF8;
 use mimetype_detector::TEXT_UTF16_BE;
 use mimetype_detector::TEXT_UTF16_LE;
-use mimetype_detector::TEXT_UTF8;
+use mimetype_detector::detect;
 
 use lru::LruCache;
 use raffia::ast::Stylesheet;

--- a/src/libs/http_method.rs
+++ b/src/libs/http_method.rs
@@ -1,7 +1,27 @@
 use hyper::Method;
 
+pub(crate) trait HyperHTTPMethodExt {
+    fn get_all_methods() -> Vec<hyper::Method>;
+}
+
 pub(crate) trait StandardMethodValidator<T> {
     fn validate(&self, err: impl FnOnce() -> T) -> Result<(), T>;
+}
+
+impl HyperHTTPMethodExt for Method {
+    fn get_all_methods() -> Vec<hyper::Method> {
+        return vec![
+            Method::CONNECT,
+            Method::DELETE,
+            Method::GET,
+            Method::HEAD,
+            Method::OPTIONS,
+            Method::PATCH,
+            Method::POST,
+            Method::PUT,
+            Method::TRACE,
+        ];
+    }
 }
 
 impl<T> StandardMethodValidator<T> for Method {

--- a/src/libs/mod.rs
+++ b/src/libs/mod.rs
@@ -25,6 +25,7 @@ pub mod preflight_type;
 pub mod protocol_result;
 pub mod reqwest_response_ext;
 pub mod response_builder_ext;
+pub mod status_code_ext;
 pub mod tap;
 pub mod tls_acceptor_ext;
 pub mod url_ext;

--- a/src/libs/status_code_ext.rs
+++ b/src/libs/status_code_ext.rs
@@ -1,0 +1,84 @@
+pub(crate) trait StatusCode {
+    fn pretty_print(&self) -> String;
+
+    fn get_all_100() -> Vec<u16>;
+
+    fn get_all_200() -> Vec<u16>;
+
+    fn get_all_300() -> Vec<u16>;
+
+    fn get_all_400() -> Vec<u16>;
+
+    fn get_all_500() -> Vec<u16>;
+
+    fn get_all_status_codes() -> Vec<u16>;
+}
+
+impl StatusCode for u16 {
+    fn get_all_100() -> Vec<u16> {
+        let mut res = Vec::new();
+        res.extend_from_slice(&[100u16, 101u16, 102u16, 103u16]);
+        res
+    }
+
+    fn get_all_200() -> Vec<u16> {
+        let mut res = Vec::new();
+        res.extend_from_slice(&[
+            200u16, 201u16, 202u16, 203u16, 204u16, 205u16, 206u16, 207u16, 208u16, 226u16,
+        ]);
+        res
+    }
+
+    fn get_all_300() -> Vec<u16> {
+        let mut res = Vec::new();
+        res.extend_from_slice(&[300u16, 301u16, 302u16, 303u16, 304u16, 307u16, 308u16]);
+        res
+    }
+
+    fn get_all_400() -> Vec<u16> {
+        let mut res = Vec::new();
+        res.extend_from_slice(&[
+            400u16, 401u16, 402u16, 403u16, 404u16, 405u16, 406u16, 407u16, 408u16, 409u16, 410u16,
+            411u16, 412u16, 413u16, 414u16, 415u16, 416u16, 417u16, 418u16, 421u16, 422u16, 423u16,
+            424u16, 425u16, 426u16, 428u16, 429u16, 431u16, 451u16,
+        ]);
+        res
+    }
+
+    fn get_all_500() -> Vec<u16> {
+        let mut res = Vec::new();
+        res.extend_from_slice(&[
+            500u16, 501u16, 502u16, 503u16, 504u16, 505u16, 506u16, 507u16, 508u16, 510u16, 511u16,
+        ]);
+        res
+    }
+
+    fn get_all_status_codes() -> Vec<u16> {
+        let http_100 = Self::get_all_100();
+        let http_200 = Self::get_all_200();
+        let http_300 = Self::get_all_300();
+        let http_400 = Self::get_all_400();
+        let http_500 = Self::get_all_500();
+
+        let mut res = Vec::new();
+
+        res.extend(http_100);
+        res.extend(http_200);
+        res.extend(http_300);
+        res.extend(http_400);
+        res.extend(http_500);
+
+        res
+    }
+
+    fn pretty_print(&self) -> String {
+        match self {
+            100u16..=199u16 => format!("⚪️ {self}"),
+            200u16..=299u16 => format!("🟢 {self}"),
+            300u16..=399u16 => format!("🔵 {self}"),
+            400u16..=499u16 => format!("🟠 {self}"),
+            500u16..=599u16 => format!("🔴 {self}"),
+            _ => "Unknown".to_string(),
+        }
+    }
+}


### PR DESCRIPTION
Enable fuzzy selection in dialoguer and implement an interactive flow for creating mocks. Users can now select HTTP methods, status codes, cache modes, and headers via a CLI wizard when the `--interactive` flag is provided.

Add helper traits to list all valid HTTP methods and status codes with formatted output for the selection menus. Update `CacheMode` to support iteration over all variants.