### PR TITLE
Add configurable proxy support to client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ mimetype-detector = "0.3.3"
 routerify_ng = "0.3.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
-reqwest = { version = "0.13.1", features = ["stream"] }
+reqwest = { version = "0.13.1", features = ["stream", "socks"] }
 path-absolutize = "3.1.1"
 raffia = "0.12.2"
 lru = "0.16.3"

--- a/src/controllers/mock_handler.rs
+++ b/src/controllers/mock_handler.rs
@@ -196,7 +196,7 @@ pub async fn mock_handler(
             req.body().clone().into_data_stream(),
         ));
 
-    // Send response if remove server is specified
+    // Send response if remote server is specified
     let Ok(response) = request_builder.send().await else {
         let response = Response::bad_gateway()
             .tap(|builder| if cors { builder.add_cors() } else { builder })

--- a/src/libs/global_config.rs
+++ b/src/libs/global_config.rs
@@ -2,6 +2,7 @@ use crate::libs::get_info_async::GetInfoAsync;
 use crate::libs::path_buf_ext::PathBufExt;
 use crate::libs::preflight_type::PreflightType;
 use crate::middlewares::logger::VerbosityLevel;
+use reqwest::Proxy;
 use serde::{Deserialize, Serialize};
 use std::collections::LinkedList;
 use std::env::current_dir;
@@ -26,6 +27,7 @@ pub(crate) struct GlobalConfig {
     log_request: Option<VerbosityLevel>,
     verbosity: Option<VerbosityLevel>,
     proxy_body_max_bytes: Option<usize>,
+    proxy: Option<String>,
 }
 
 pub(crate) trait GlobalConfigBuilder {
@@ -139,6 +141,10 @@ impl GlobalConfig {
             .map(|o| o.proxy_body_max_bytes)
             .flatten()
             .or(self.proxy_body_max_bytes);
+        let proxy = other
+            .map(|o| o.proxy.clone())
+            .flatten()
+            .or_else(|| self.proxy.clone());
         GlobalConfig {
             host,
             port,
@@ -152,6 +158,7 @@ impl GlobalConfig {
             log_request,
             verbosity,
             proxy_body_max_bytes,
+            proxy,
         }
     }
 }
@@ -287,6 +294,13 @@ impl GlobalConfigAPI {
 
     pub async fn get_proxy_body_max_bytes(&self) -> Option<usize> {
         self.get_config().await.proxy_body_max_bytes
+    }
+
+    pub async fn get_proxy(&self) -> Option<Proxy> {
+        match self.get_config().await.proxy {
+            Some(p) => Proxy::all(p).ok(),
+            None => None,
+        }
     }
 }
 

--- a/src/server/mockers_router.rs
+++ b/src/server/mockers_router.rs
@@ -23,7 +23,7 @@ use crate::middlewares::logger::logger;
 use crate::server::mockers_context::MockersContext;
 use crate::server::params::ServerParams;
 use crate::server::route_error::MockersRouteError;
-use reqwest::Client;
+use reqwest::ClientBuilder;
 use routerify_ng::Router;
 use routerify_ng::{Middleware, RouteError};
 
@@ -79,8 +79,13 @@ pub async fn mockers_router(
     swagger_base_path: &'static str,
 ) -> Result<Router<MockersRouteError>, RouteError> {
     let router_builder = {
+        let mut client = ClientBuilder::new().no_proxy();
+        if let Some(proxy) = params.proxy().await {
+            client = client.proxy(proxy);
+        }
+        let client = client.build()?;
         let mut router = Router::builder().data(Arc::new(MockersContext {
-            client: Arc::new(Client::new()),
+            client: Arc::new(client),
             server_params: params.clone(),
         }));
         if let Some((admin_base_url, admin_router)) = params

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -14,6 +14,7 @@ use hyper::service::Service;
 use hyper_util::rt::TokioIo;
 use hyper_util::server::graceful::GracefulShutdown;
 use log::{error, info};
+use reqwest::Proxy;
 use routerify_ng::RouterService;
 use std::net::ToSocketAddrs;
 use std::path::PathBuf;
@@ -96,6 +97,12 @@ pub struct ServerParams {
 
     #[arg(long, help = "Maximum response size in bytes")]
     proxy_body_max_bytes: Option<usize>,
+
+    #[arg(
+        long = "proxy",
+        help = "Proxy connection string, example: socks5h://127.0.0.1:1080, https://proxy-gateway.whatever:443/"
+    )]
+    proxy: Option<String>,
 
     #[clap(skip)]
     global_config: OnceCell<GlobalConfigAPI>,
@@ -227,6 +234,13 @@ impl ServerParams {
         .unwrap_or(DEFAULT_PROXY_RESPONSE_BODY_BYTES);
 
         std::cmp::min(proxy_body_max_bytes, HARD_MAX_PROXY_RESPONSE_BODY_BYTES)
+    }
+
+    pub async fn proxy(&self) -> Option<Proxy> {
+        match self.proxy.as_ref() {
+            Some(p) => Proxy::all(p.as_str()).ok(),
+            None => self.get_global_config().await.get_proxy().await,
+        }
     }
 
     pub async fn test(&self) -> anyhow::Result<()> {


### PR DESCRIPTION
- Enable the `socks` feature for `reqwest` in Cargo.toml
- Introduce a `proxy` field in `GlobalConfig` and merge logic
- Add `GlobalConfigAPI::get_proxy` returning a `reqwest::Proxy`
- Add CLI `--proxy` option to `ServerParams` and helper method to obtain a proxy
- Build `reqwest::Client` with `ClientBuilder`, applying the proxy when set
- Fix typo in comment from “remove” to “remote” in mock handler